### PR TITLE
fixes #17: no need to specify typography inside shared components

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2 || ^2.0.0",
     "d2l-colors": "^2.4.0 || ^3.1.0",
-    "d2l-typography": "^5.4.0 || ^6.0.0",
     "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0"
   },
   "devDependencies": {
@@ -30,7 +29,6 @@
       "dependencies": {
         "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
         "d2l-colors": "^2.4.0",
-        "d2l-typography": "^5.4.0",
         "polymer": "Polymer/polymer#^1.9.1"
       },
       "devDependencies": {

--- a/d2l-file-uploader.html
+++ b/d2l-file-uploader.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../app-localize-behavior/app-localize-behavior.html">
-<link rel="import" href="../d2l-typography/d2l-typography.html">
 <!--
 `d2l-file-uploader` is a web component for uploading files.
 
@@ -9,9 +8,9 @@
 -->
 <dom-module id="d2l-file-uploader">
 	<template strip-whitespace>
-		<style include="d2l-typography">
+		<style>
 			.d2l-file-uploader-drop-zone {
-				border: 2px dashed;
+				border: 2px dashed var(--d2l-color-ferrite);
 				border-radius: 0.3rem;
 				height: auto;
 				max-width: 27rem;
@@ -163,7 +162,7 @@
 			}
 		</style>
 
-		<div class="d2l-typography">
+		<div>
 			<div>
 				<div class="d2l-file-uploader-error" role="alert" hidden$="{{!error}}">{{errorMessage}}</div>
 			</div>


### PR DESCRIPTION
The parent application is the one responsible for typography, so individual shared components don't need to each specify it over and over again.