### PR TITLE
using the link component's mixins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2 || ^2.0.0",
     "d2l-colors": "^2.4.0 || ^3.1.0",
-    "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0"
+    "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0",
+    "d2l-link": "^3.5.1"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
@@ -36,10 +37,10 @@
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.2.6",
         "iron-test-helpers": "^1.4.1",
         "web-component-tester": "^6.0.0",
-        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.24"
       },
       "resolutions": {
-        "webcomponentsjs": "^v0.7.0"
+        "webcomponentsjs": "^v0.7.24"
       }
     }
   },

--- a/d2l-file-uploader.html
+++ b/d2l-file-uploader.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../app-localize-behavior/app-localize-behavior.html">
+<link rel="import" href="../d2l-link/d2l-link-shared-styles.html">
 <!--
 `d2l-file-uploader` is a web component for uploading files.
 
@@ -43,17 +44,12 @@
 			}
 
 			.d2l-file-uploader-browse-label {
-				background: none;
-				border: none;
-				color: var(--d2l-color-celestine);
-				overflow: hidden;
-				padding-right: 0;
+				@apply --d2l-link;
 				position: relative;
 			}
 			.d2l-file-uploader-browse-label:hover,
 			.d2l-file-uploader-browse-label-focus {
-				color: var(--d2l-color-celestine-minus-1);
-				text-decoration: underline;
+				@apply --d2l-link-hover;
 			}
 
 			.d2l-file-uploader-browse-files {


### PR DESCRIPTION
The link component actually [exposes mixins](https://github.com/BrightspaceUI/link/blob/master/d2l-link-shared-styles.html#L6) to apply its styles to other things, so using them here to remove some duplicate CSS.