### PR TITLE
Change file upload text and cut down to one string

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To allow for multiple files to be uploaded, add the `multiple` attribute:
 
 ### Setting the Language
 
-The `language` attribute sets the language the file uploader should use. Currently supported values are: `en`, `ar-SA`, `de-DE`, `es-MX`, `fr-CA`, `ja-JP`, `ko-KR`, `nb-NO`, `nl-NL`, `pt-BR`, `sv-SE`, `tr-TR`, `zh-CN`, `zh-TW`.
+The `language` attribute sets the language the file uploader should use. Currently supported values are: `en`, `ar-SA`, `de-DE`, `es-MX`, `fr-CA`, `ja`, `ko-KR`, `nb-NO`, `nl-NL`, `pt-BR`, `sv-SE`, `tr-TR`, `zh-CN`, `zh-TW`.
 
 If the language attribute is not present, it will default to English.
 

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2 || ^2.0.0",
     "d2l-colors": "^2.4.0 || ^3.1.0",
     "d2l-offscreen": "^3.0.1 || ^2.2.5",
-    "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0"
+    "polymer": "Polymer/polymer#^1.9.3 || ^2.0.2"
   },
   "devDependencies": {
     "d2l-typography": "^6.0.0 || ^5.4.0",
@@ -24,7 +24,7 @@
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
     "iron-test-helpers": "^2.0.0",
     "web-component-tester": "^6.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.5"
   },
   "variants": {
     "1.x": {
@@ -32,7 +32,7 @@
         "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
         "d2l-colors": "^2.4.0",
         "d2l-offscreen": "^2.2.5",
-        "polymer": "Polymer/polymer#^1.9.1"
+        "polymer": "Polymer/polymer#^1.9.3"
       },
       "devDependencies": {
         "d2l-typography": "^5.4.0",
@@ -40,14 +40,14 @@
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.2.6",
         "iron-test-helpers": "^1.4.1",
         "web-component-tester": "^6.0.0",
-        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.24"
       },
       "resolutions": {
-        "webcomponentsjs": "^v0.7.0"
+        "webcomponentsjs": "^v0.7.24"
       }
     }
   },
   "resolutions": {
-    "webcomponentsjs": "^v1.0.0"
+    "webcomponentsjs": "^v1.0.5"
   }
 }

--- a/d2l-file-uploader.html
+++ b/d2l-file-uploader.html
@@ -272,7 +272,7 @@
 				this.unlisten(document, 'drop', '__onDrop');
 			},
 
-			_computeMessage: function(localize, multiple) {
+			_computeMessage: function(localize) {
 				var term = 'file_upload_text';
 				return localize(term);
 			},

--- a/d2l-file-uploader.html
+++ b/d2l-file-uploader.html
@@ -158,7 +158,7 @@
 				<path fill="#565a5c" d="M78 36.14a17.52 17.52 0 0 1-17.5 17.5c-.17 0-1.33 0-1.5-.02l-12.51.02a1.333 1.333 0 0 1-.49-.09 1.494 1.494 0 0 1 0-2.82 1.386 1.386 0 0 1 .5-.09h14a14.5 14.5 0 0 0 1.58-28.92c-.52-.05-1.05-.08-1.58-.08h-.35a1.49 1.49 0 0 1-1-.4 2.258 2.258 0 0 1-.542-1.075c-.138-.462-.306-.916-.478-1.365a20.484 20.484 0 0 0-38.26 0q-.21.54-.39 1.08a3.353 3.353 0 0 1-.53 1.26 1.542 1.542 0 0 1-1.12.5h-.33c-.53 0-1.06.03-1.58.08a14.5 14.5 0 0 0 1.58 28.92h13.99a1.5 1.5 0 0 1 .01 3s-13.5 0-13.5-.02a4.176 4.176 0 0 1-.5.02 17.5 17.5 0 0 1-.77-34.98 23.49 23.49 0 0 1 44.54 0A17.52 17.52 0 0 1 78 36.14z"/>
 			</svg>
 			<div>
-				<span>{{_message}}&nbsp;</span>
+				<span>{{localize('file_upload_text')}}&nbsp;</span>
 				<span class="d2l-file-uploader-input-container">
 					<span id="d2l-file-uploader-offscreen">[[label]]</span>
 					<label class="d2l-file-uploader-browse-label">
@@ -244,13 +244,6 @@
 					type: Boolean,
 					value: false,
 					reflectToAttribute: true
-				},
-				/**
-				 * Message to display to the user.
-				 */
-				_message: {
-					type: String,
-					computed: '_computeMessage(localize, multiple)'
 				}
 			},
 
@@ -270,11 +263,6 @@
 				this.unlisten(document, 'dragleave', '__onDragLeave');
 				this.unlisten(document, 'dragend', '__onDragEnd');
 				this.unlisten(document, 'drop', '__onDrop');
-			},
-
-			_computeMessage: function(localize) {
-				var term = 'file_upload_text';
-				return localize(term);
 			},
 
 			_fileSelectHandler: function(event) {

--- a/d2l-file-uploader.html
+++ b/d2l-file-uploader.html
@@ -273,7 +273,7 @@
 			},
 
 			_computeMessage: function(localize, multiple) {
-				var term = multiple ? 'multiple_file_upload_text' : 'single_file_upload_text';
+				var term = 'file_upload_text';
 				return localize(term);
 			},
 

--- a/locales.json
+++ b/locales.json
@@ -42,7 +42,7 @@
     "choose_one_file_to_upload": "Elija un archivo para cargar"
   },
   "fr-CA": {
-    "file_upload_text": "Glissez-déposez un fichier n'importe où dans cet écran ou",
+    "file_upload_text": "Glissez-déposez ou",
     "browse": "parcourir",
     "browse_files": "Parcourir les fichiers",
     "choose_one_file_to_upload": "Choisir un fichier à téléverser"

--- a/locales.json
+++ b/locales.json
@@ -1,119 +1,102 @@
 {
   "en": {
-    "single_file_upload_text": "Drag and drop a file anywhere on this screen or",
-    "multiple_file_upload_text": "Drag and drop files anywhere on this screen or",
+    "file_upload_text": "Drag and drop or",
     "browse": "browse",
     "browse_files": "Browse Files",
     "choose_one_file_to_upload": "Choose one file to upload"
   },
   "en-US": {
-    "single_file_upload_text": "Drag and drop a file anywhere on this screen or",
-    "multiple_file_upload_text": "Drag and drop files anywhere on this screen or",
+    "file_upload_text": "Drag and drop or",
     "browse": "browse",
     "browse_files": "Browse Files",
     "choose_one_file_to_upload": "Choose one file to upload"
   },
   "en-CA": {
-    "single_file_upload_text": "Drag and drop a file anywhere on this screen or",
-    "multiple_file_upload_text": "Drag and drop files anywhere on this screen or",
+    "file_upload_text": "Drag and drop or",
     "browse": "browse",
     "browse_files": "Browse Files",
     "choose_one_file_to_upload": "Choose one file to upload"
   },
   "en-GB": {
-    "single_file_upload_text": "Drag and drop a file anywhere on this screen or",
-    "multiple_file_upload_text": "Drag and drop files anywhere on this screen or",
+    "file_upload_text": "Drag and drop or",
     "browse": "browse",
     "browse_files": "Browse Files",
     "choose_one_file_to_upload": "Choose one file to upload"
   },
   "ar-SA": {
-    "single_file_upload_text": "اسحب ملفًا وافلته في أي مكان على هذه الشاشة أو ",
-    "multiple_file_upload_text": "اسحب ملفات وافلتها في أي مكان على هذه الشاشة أو ",
+    "file_upload_text": "اسحب ملفًا وافلته في أي مكان على هذه الشاشة أو ",
     "browse": "استعراض",
     "browse_files": "استعراض الملفات",
     "choose_one_file_to_upload": "اختر ملفًا لتحميله"
   },
   "de-DE": {
-    "single_file_upload_text": "Datei an eine beliebige Stelle dieses Bildschirms verschieben oder",
-    "multiple_file_upload_text": "Dateien an eine beliebige Stelle dieses Bildschirms verschieben oder",
+    "file_upload_text": "Datei an eine beliebige Stelle dieses Bildschirms verschieben oder",
     "browse": "durchsuchen",
     "browse_files": "Dateien durchsuchen",
     "choose_one_file_to_upload": "Wählen Sie eine Datei zum Hochladen aus"
   },
   "es-MX": {
-    "single_file_upload_text": "Arrastre y suelte un archivo en cualquier parte de esta pantalla o",
-    "multiple_file_upload_text": "Arrastre y suelte archivos en cualquier parte de esta pantalla o",
+    "file_upload_text": "Arrastre y suelte un archivo en cualquier parte de esta pantalla o",
     "browse": "examinar",
     "browse_files": "Examinar archivos",
     "choose_one_file_to_upload": "Elija un archivo para cargar"
   },
   "fr-CA": {
-    "single_file_upload_text": "Glissez-déposez un fichier n'importe où dans cet écran ou",
-    "multiple_file_upload_text": "Glissez-déposez des fichiers n'importe où dans cet écran ou",
+    "file_upload_text": "Glissez-déposez un fichier n'importe où dans cet écran ou",
     "browse": "parcourir",
     "browse_files": "Parcourir les fichiers",
     "choose_one_file_to_upload": "Choisir un fichier à téléverser"
   },
-  "ja-JP": {
-    "single_file_upload_text": "この画面にファイルをドラッグ＆ドロップ、または",
-    "multiple_file_upload_text": "この画面に複数のファイルをドラッグ＆ドロップ、または",
+  "ja": {
+    "file_upload_text": "この画面にファイルをドラッグ＆ドロップ、または",
     "browse": "参照",
     "browse_files": "ファイルの参照",
     "choose_one_file_to_upload": "アップロードするファイルを 1 つ選択"
   },
   "ko-KR": {
-    "single_file_upload_text": "파일을 이 화면의 아무 곳에서 끌어서 놓거나",
-    "multiple_file_upload_text": "파일을 이 화면의 아무 곳에서 끌어서 놓거나",
+    "file_upload_text": "파일을 이 화면의 아무 곳에서 끌어서 놓거나",
     "browse": "찾아보기",
     "browse_files": "파일 찾아보기",
     "choose_one_file_to_upload": "업로드할 파일 하나 선택"
   },
   "nb-NO": {
-    "single_file_upload_text": "Dra og slipp en fil til denne visningen eller",
-    "multiple_file_upload_text": "Dra og slipp filer til denne visningen eller",
+    "file_upload_text": "Dra og slipp en fil til denne visningen eller",
     "browse": "bla",
     "browse_files": "Bla i filer",
     "choose_one_file_to_upload": "Velg én fil som skal lastes opp"
   },
   "nl-NL": {
-    "single_file_upload_text": "Sleep een bestand en zet het ergens op dit scherm neer of",
-    "multiple_file_upload_text": "Sleep bestanden en zet ze ergens op dit scherm neer of",
+    "file_upload_text": "Sleep een bestand en zet het ergens op dit scherm neer of",
     "browse": "blader",
     "browse_files": "Door bestanden bladeren",
     "choose_one_file_to_upload": "Kies een bestand dat u wilt uploaden"
   },
   "pt-BR": {
-    "single_file_upload_text": "Arraste e solte um arquivo em qualquer lugar nesta tela ou",
-    "multiple_file_upload_text": "Arraste e solte arquivos em qualquer lugar nesta tela ou",
+    "file_upload_text": "Arraste e solte um arquivo em qualquer lugar nesta tela ou",
     "browse": "procurar",
     "browse_files": "Procurar arquivos",
     "choose_one_file_to_upload": "Escolha um arquivo para carregar"
   },
   "sv-SE": {
-    "single_file_upload_text": "Dra och släpp en fil var som helst på skärmen eller",
-    "multiple_file_upload_text": "Dra och släpp filer var som helst på skärmen eller",
+    "file_upload_text": "Dra och släpp en fil var som helst på skärmen eller",
     "browse": "bläddra",
     "browse_files": "Bläddra bland filer",
     "choose_one_file_to_upload": "Välj en fil att ladda upp"
   },
   "tr-TR": {
-    "single_file_upload_text": "Bir dosyayı bu ekranda herhangi bir yere sürükleyip bırakın ya da",
-    "multiple_file_upload_text": "Dosyaları bu ekranda herhangi bir yere sürükleyip bırakın ya da",
+    "file_upload_text": "Bir dosyayı bu ekranda herhangi bir yere sürükleyip bırakın ya da",
     "browse": "göz atın",
     "browse_files": "Dosyalara Göz At",
     "choose_one_file_to_upload": "Yüklemek için bir dosya seçin"
   },
   "zh-CN": {
-    "single_file_upload_text": "拖放一个文件到该屏幕的任何位置或者",
-    "multiple_file_upload_text": "拖放多个文件到该屏幕的任何位置或者",
+    "file_upload_text": "拖放一个文件到该屏幕的任何位置或者",
     "browse": "浏览",
     "browse_files": "浏览文件",
     "choose_one_file_to_upload": "选择一个要上传的文件"
   },
   "zh-TW": {
-    "single_file_upload_text": "將一個檔案拖放至此畫面上的任何位置，或者",
-    "multiple_file_upload_text": "將多個檔案拖放至此畫面上的任何位置，或者",
+    "file_upload_text": "將一個檔案拖放至此畫面上的任何位置，或者",
     "browse": "瀏覽",
     "browse_files": "瀏覽檔案",
     "choose_one_file_to_upload": "選擇要上傳的檔案"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "eslint": "^4.1.1",
     "eslint-config-brightspace": "^0.3.1",
     "eslint-plugin-html": "^3.0.0",
-    "polymer-cli": "^1.2.0"
+    "polymer-cli": "^1.5.2"
   }
 }

--- a/test/d2l-file-uploader.html
+++ b/test/d2l-file-uploader.html
@@ -150,7 +150,7 @@
 
 					it('should have language of "fr-CA"', function() {
 						expect(elem.language).to.equal('fr-CA');
-						expect(elem._message).to.equal('Glissez-déposez un fichier n\'importe où dans cet écran ou');
+						expect(elem.$$('.d2l-file-uploader-drop-zone > div > span:first-child').innerText).to.equal('Glissez-déposez un fichier n\'importe où dans cet écran ou ');
 					});
 
 				});

--- a/test/d2l-file-uploader.html
+++ b/test/d2l-file-uploader.html
@@ -150,7 +150,7 @@
 
 					it('should have language of "fr-CA"', function() {
 						expect(elem.language).to.equal('fr-CA');
-						expect(elem.$$('.d2l-file-uploader-drop-zone > div > span:first-child').innerText).to.equal('Glissez-déposez un fichier n\'importe où dans cet écran ou ');
+						expect(elem.$$('.d2l-file-uploader-drop-zone > div > span:first-child').innerHTML).to.equal('Glissez-déposez ou&nbsp;');
 					});
 
 				});

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,8 @@
 	<body>
 		<script>
 			WCT.loadSuites([
-				'd2l-file-uploader.html',
+				'd2l-file-uploader.html?wc-shadydom=true&wc-ce=true',
+				'd2l-file-uploader.html?dom=shadow&lazyRegister=true&useNativeCSSProperties=true',
 				'd2l-file-uploader.html?dom=shadow'
 			]);
 		</script>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -34,11 +34,6 @@
 					"browserName": "microsoftedge",
 					"platform": "Windows 10",
 					"version": ""
-				},
-				{
-					"browserName": "internet explorer",
-					"platform": "Windows 10",
-					"version": "11"
 				}
 			]
 		}


### PR DESCRIPTION
@nicolebezaire wanted a change to the file_upload_text, and wanted to cut down from two strings to one and simplify. I left the single_file_upload_text string in for other languages, so that will need to be newly translated (which I can send the new string out for translation). Also, I made a change to get the Japanese strings working (no regions for Japan).

If you'd prefer that the PR be merged after the translations come back, I can do that as well, but I feel like it would also be easy to create another PR.