### PR TITLE
switching to use d2l-localize-behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,9 @@ To allow for multiple files to be uploaded, add the `multiple` attribute:
 <d2l-file-uploader multiple ...></d2l-file-uploader>
 ```
 
-### Setting the Language
+### Localization
 
-The `language` attribute sets the language the file uploader should use. Currently supported values are: `en`, `ar-SA`, `de-DE`, `es-MX`, `fr-CA`, `ja`, `ko-KR`, `nb-NO`, `nl-NL`, `pt-BR`, `sv-SE`, `tr-TR`, `zh-CN`, `zh-TW`.
-
-If the language attribute is not present, it will default to English.
-
-```html
-<d2l-file-uploader language="fr-CA" ...></d2l-file-uploader>
-```
+The file uploader will automatically render using the language found on the HTML element -- i.e. `<html lang="fr">`. If the language attribute is not present or isn't supported, the uploader will render in English.
 
 ![screenshot of file uploader localized](/screenshots/localized.png?raw=true)
 

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,8 @@
     "test"
   ],
   "dependencies": {
-    "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2 || ^2.0.0",
     "d2l-colors": "^2.4.0 || ^3.1.0",
+    "d2l-localize-behavior": "^1.0.0",
     "d2l-offscreen": "^3.0.1 || ^2.2.5",
     "polymer": "Polymer/polymer#^1.9.3 || ^2.0.2"
   },
@@ -29,7 +29,6 @@
   "variants": {
     "1.x": {
       "dependencies": {
-        "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
         "d2l-colors": "^2.4.0",
         "d2l-offscreen": "^2.2.5",
         "polymer": "Polymer/polymer#^1.9.3"

--- a/d2l-file-uploader.html
+++ b/d2l-file-uploader.html
@@ -182,7 +182,7 @@
 			is: 'd2l-file-uploader',
 
 			behaviors: [
-				window.D2L.PolymerBehaviors.FileUploader.LocalizeBehavior
+				D2L.PolymerBehaviors.FileUploader.LocalizeBehavior
 			],
 
 			properties: {

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,13 +38,6 @@
 				</template>
 			</demo-snippet>
 
-			<h2>Customized Language</h2>
-			<demo-snippet>
-				<template>
-					<d2l-file-uploader language="fr-CA"></d2l-file-uploader>
-				</template>
-			</demo-snippet>
-
 			<h2>Feedback</h2>
 			<demo-snippet>
 				<template>

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -1,223 +1,108 @@
-<link rel="import" href="../app-localize-behavior/app-localize-behavior.html">
+<link rel="import" href="../d2l-localize-behavior/d2l-localize-behavior.html">
 <script>
-	(function() {
-		'use strict';
-		/** @polymerBehavior LocalizeBehavior */
-		var LocalizeBehavior = {
-			properties: {
-				language: {
-					type: String,
-					value: 'en'
-				},
+	window.D2L = window.D2L || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+	window.D2L.PolymerBehaviors.FileUploader = window.D2L.PolymerBehaviors.FileUploader || {};
 
-				resources: {
-					value: function() {
-						return {
-							'en': {
-								'file_upload_text': 'Drag and drop or',
-								'browse': 'browse',
-								'browse_files': 'Browse Files',
-								'choose_one_file_to_upload': 'Choose one file to upload'
-							},
-							'en-us': {
-								'file_upload_text': 'Drag and drop or',
-								'browse': 'browse',
-								'browse_files': 'Browse Files',
-								'choose_one_file_to_upload': 'Choose one file to upload'
-							},
-							'en-ca': {
-								'file_upload_text': 'Drag and drop or',
-								'browse': 'browse',
-								'browse_files': 'Browse Files',
-								'choose_one_file_to_upload': 'Choose one file to upload'
-							},
-							'en-gb': {
-								'file_upload_text': 'Drag and drop or',
-								'browse': 'browse',
-								'browse_files': 'Browse Files',
-								'choose_one_file_to_upload': 'Choose one file to upload'
-							},
-							'ar': {
-								'file_upload_text': 'اسحب ملفًا وافلته في أي مكان على هذه الشاشة أو ',
-								'browse': 'استعراض',
-								'browse_files': 'استعراض الملفات',
-								'choose_one_file_to_upload': 'اختر ملفًا لتحميله'
-							},
-							'ar-sa': {
-								'file_upload_text': 'اسحب ملفًا وافلته في أي مكان على هذه الشاشة أو ',
-								'browse': 'استعراض',
-								'browse_files': 'استعراض الملفات',
-								'choose_one_file_to_upload': 'اختر ملفًا لتحميله'
-							},
-							'de': {
-								'file_upload_text': 'Datei an eine beliebige Stelle dieses Bildschirms verschieben oder',
-								'browse': 'durchsuchen',
-								'browse_files': 'Dateien durchsuchen',
-								'choose_one_file_to_upload': 'Wählen Sie eine Datei zum Hochladen aus'
-							},
-							'de-de': {
-								'file_upload_text': 'Datei an eine beliebige Stelle dieses Bildschirms verschieben oder',
-								'browse': 'durchsuchen',
-								'browse_files': 'Dateien durchsuchen',
-								'choose_one_file_to_upload': 'Wählen Sie eine Datei zum Hochladen aus'
-							},
-							'es': {
-								'file_upload_text': 'Arrastre y suelte un archivo en cualquier parte de esta pantalla o',
-								'browse': 'examinar',
-								'browse_files': 'Examinar archivos',
-								'choose_one_file_to_upload': 'Elija un archivo para cargar'
-							},
-							'es-mx': {
-								'file_upload_text': 'Arrastre y suelte un archivo en cualquier parte de esta pantalla o',
-								'browse': 'examinar',
-								'browse_files': 'Examinar archivos',
-								'choose_one_file_to_upload': 'Elija un archivo para cargar'
-							},
-							'fr': {
-								'file_upload_text': 'Glissez-déposez ou',
-								'browse': 'parcourir',
-								'browse_files': 'Parcourir les fichiers',
-								'choose_one_file_to_upload': 'Choisir un fichier à téléverser'
-							},
-							'fr-ca': {
-								'file_upload_text': 'Glissez-déposez ou',
-								'browse': 'parcourir',
-								'browse_files': 'Parcourir les fichiers',
-								'choose_one_file_to_upload': 'Choisir un fichier à téléverser'
-							},
-							'ja': {
-								'file_upload_text': 'この画面にファイルをドラッグ＆ドロップ、または',
-								'browse': '参照',
-								'browse_files': 'ファイルの参照',
-								'choose_one_file_to_upload': 'アップロードするファイルを 1 つ選択'
-							},
-							'ja-jp': {
-								'file_upload_text': 'この画面にファイルをドラッグ＆ドロップ、または',
-								'browse': '参照',
-								'browse_files': 'ファイルの参照',
-								'choose_one_file_to_upload': 'アップロードするファイルを 1 つ選択'
-							},
-							'ko': {
-								'file_upload_text': '파일을 이 화면의 아무 곳에서 끌어서 놓거나',
-								'browse': '찾아보기',
-								'browse_files': '파일 찾아보기',
-								'choose_one_file_to_upload': '업로드할 파일 하나 선택'
-							},
-							'ko-kr': {
-								'file_upload_text': '파일을 이 화면의 아무 곳에서 끌어서 놓거나',
-								'browse': '찾아보기',
-								'browse_files': '파일 찾아보기',
-								'choose_one_file_to_upload': '업로드할 파일 하나 선택'
-							},
-							'nb': {
-								'file_upload_text': 'Dra og slipp en fil til denne visningen eller',
-								'browse': 'bla',
-								'browse_files': 'Bla i filer',
-								'choose_one_file_to_upload': 'Velg én fil som skal lastes opp'
-							},
-							'nb-no': {
-								'file_upload_text': 'Dra og slipp en fil til denne visningen eller',
-								'browse': 'bla',
-								'browse_files': 'Bla i filer',
-								'choose_one_file_to_upload': 'Velg én fil som skal lastes opp'
-							},
-							'nl': {
-								'file_upload_text': 'Sleep een bestand en zet het ergens op dit scherm neer of',
-								'browse': 'blader',
-								'browse_files': 'Door bestanden bladeren',
-								'choose_one_file_to_upload': 'Kies een bestand dat u wilt uploaden'
-							},
-							'nl-nl': {
-								'file_upload_text': 'Sleep een bestand en zet het ergens op dit scherm neer of',
-								'browse': 'blader',
-								'browse_files': 'Door bestanden bladeren',
-								'choose_one_file_to_upload': 'Kies een bestand dat u wilt uploaden'
-							},
-							'pt': {
-								'file_upload_text': 'Arraste e solte um arquivo em qualquer lugar nesta tela ou',
-								'browse': 'procurar',
-								'browse_files': 'Procurar arquivos',
-								'choose_one_file_to_upload': 'Escolha um arquivo para carregar'
-							},
-							'pt-br': {
-								'file_upload_text': 'Arraste e solte um arquivo em qualquer lugar nesta tela ou',
-								'browse': 'procurar',
-								'browse_files': 'Procurar arquivos',
-								'choose_one_file_to_upload': 'Escolha um arquivo para carregar'
-							},
-							'sv': {
-								'file_upload_text': 'Dra och släpp en fil var som helst på skärmen eller',
-								'browse': 'bläddra',
-								'browse_files': 'Bläddra bland filer',
-								'choose_one_file_to_upload': 'Välj en fil att ladda upp'
-							},
-							'sv-se': {
-								'file_upload_text': 'Dra och släpp en fil var som helst på skärmen eller',
-								'browse': 'bläddra',
-								'browse_files': 'Bläddra bland filer',
-								'choose_one_file_to_upload': 'Välj en fil att ladda upp'
-							},
-							'tr': {
-								'file_upload_text': 'Bir dosyayı bu ekranda herhangi bir yere sürükleyip bırakın ya da',
-								'browse': 'göz atın',
-								'browse_files': 'Dosyalara Göz At',
-								'choose_one_file_to_upload': 'Yüklemek için bir dosya seçin'
-							},
-							'tr-tr': {
-								'file_upload_text': 'Bir dosyayı bu ekranda herhangi bir yere sürükleyip bırakın ya da',
-								'browse': 'göz atın',
-								'browse_files': 'Dosyalara Göz At',
-								'choose_one_file_to_upload': 'Yüklemek için bir dosya seçin'
-							},
-							'zh': {
-								'file_upload_text': '拖放一个文件到该屏幕的任何位置或者',
-								'browse': '浏览',
-								'browse_files': '浏览文件',
-								'choose_one_file_to_upload': '选择一个要上传的文件'
-							},
-							'zh-cn': {
-								'file_upload_text': '拖放一个文件到该屏幕的任何位置或者',
-								'browse': '浏览',
-								'browse_files': '浏览文件',
-								'choose_one_file_to_upload': '选择一个要上传的文件'
-							},
-							'zh-tw': {
-								'file_upload_text': '將一個檔案拖放至此畫面上的任何位置，或者',
-								'browse': '瀏覽',
-								'browse_files': '瀏覽檔案',
-								'choose_one_file_to_upload': '選擇要上傳的檔案'
-							}
-						};
-					}
+	/** @polymerBehavior D2L.PolymerBehaviors.FileUploader.LocalizeBehaviorImpl */
+	D2L.PolymerBehaviors.FileUploader.LocalizeBehaviorImpl = {
+		properties: {
+			resources: {
+				value: function() {
+					return {
+						'en': {
+							'file_upload_text': 'Drag and drop or',
+							'browse': 'browse',
+							'browse_files': 'Browse Files',
+							'choose_one_file_to_upload': 'Choose one file to upload'
+						},
+						'ar': {
+							'file_upload_text': 'اسحب ملفًا وافلته في أي مكان على هذه الشاشة أو ',
+							'browse': 'استعراض',
+							'browse_files': 'استعراض الملفات',
+							'choose_one_file_to_upload': 'اختر ملفًا لتحميله'
+						},
+						'de': {
+							'file_upload_text': 'Datei an eine beliebige Stelle dieses Bildschirms verschieben oder',
+							'browse': 'durchsuchen',
+							'browse_files': 'Dateien durchsuchen',
+							'choose_one_file_to_upload': 'Wählen Sie eine Datei zum Hochladen aus'
+						},
+						'es': {
+							'file_upload_text': 'Arrastre y suelte un archivo en cualquier parte de esta pantalla o',
+							'browse': 'examinar',
+							'browse_files': 'Examinar archivos',
+							'choose_one_file_to_upload': 'Elija un archivo para cargar'
+						},
+						'fr': {
+							'file_upload_text': 'Glissez-déposez ou',
+							'browse': 'parcourir',
+							'browse_files': 'Parcourir les fichiers',
+							'choose_one_file_to_upload': 'Choisir un fichier à téléverser'
+						},
+						'ja': {
+							'file_upload_text': 'この画面にファイルをドラッグ＆ドロップ、または',
+							'browse': '参照',
+							'browse_files': 'ファイルの参照',
+							'choose_one_file_to_upload': 'アップロードするファイルを 1 つ選択'
+						},
+						'ko': {
+							'file_upload_text': '파일을 이 화면의 아무 곳에서 끌어서 놓거나',
+							'browse': '찾아보기',
+							'browse_files': '파일 찾아보기',
+							'choose_one_file_to_upload': '업로드할 파일 하나 선택'
+						},
+						'nl': {
+							'file_upload_text': 'Sleep een bestand en zet het ergens op dit scherm neer of',
+							'browse': 'blader',
+							'browse_files': 'Door bestanden bladeren',
+							'choose_one_file_to_upload': 'Kies een bestand dat u wilt uploaden'
+						},
+						'pt': {
+							'file_upload_text': 'Arraste e solte um arquivo em qualquer lugar nesta tela ou',
+							'browse': 'procurar',
+							'browse_files': 'Procurar arquivos',
+							'choose_one_file_to_upload': 'Escolha um arquivo para carregar'
+						},
+						'sv': {
+							'file_upload_text': 'Dra och släpp en fil var som helst på skärmen eller',
+							'browse': 'bläddra',
+							'browse_files': 'Bläddra bland filer',
+							'choose_one_file_to_upload': 'Välj en fil att ladda upp'
+						},
+						'tr': {
+							'file_upload_text': 'Bir dosyayı bu ekranda herhangi bir yere sürükleyip bırakın ya da',
+							'browse': 'göz atın',
+							'browse_files': 'Dosyalara Göz At',
+							'choose_one_file_to_upload': 'Yüklemek için bir dosya seçin'
+						},
+						'zh': {
+							'file_upload_text': '拖放一个文件到该屏幕的任何位置或者',
+							'browse': '浏览',
+							'browse_files': '浏览文件',
+							'choose_one_file_to_upload': '选择一个要上传的文件'
+						},
+						'zh-cn': {
+							'file_upload_text': '拖放一个文件到该屏幕的任何位置或者',
+							'browse': '浏览',
+							'browse_files': '浏览文件',
+							'choose_one_file_to_upload': '选择一个要上传的文件'
+						},
+						'zh-tw': {
+							'file_upload_text': '將一個檔案拖放至此畫面上的任何位置，或者',
+							'browse': '瀏覽',
+							'browse_files': '瀏覽檔案',
+							'choose_one_file_to_upload': '選擇要上傳的檔案'
+						}
+					};
 				}
-			},
-
-			observers: [
-				'_computeLanguage( resources, language )'
-			],
-
-			_computeLanguage: function(resources, language) {
-				var locale = language;
-				locale = locale.toLowerCase();
-				if (resources[locale]) {
-					this.language = locale;
-					return;
-				}
-				var langAndRegion = locale.split('-');
-				if (resources[langAndRegion[0]]) {
-					this.language =  langAndRegion[0];
-					return;
-				}
-				this.language =  'en';
 			}
-		};
-		window.D2L = window.D2L || {};
-		window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
-		window.D2L.PolymerBehaviors.FileUploader = window.D2L.PolymerBehaviors.FileUploader || {};
-		/** @polymerBehavior */
-		window.D2L.PolymerBehaviors.FileUploader.LocalizeBehavior = [
-			Polymer.AppLocalizeBehavior,
-			LocalizeBehavior
-		];
-	})();
+		}
+	};
+
+	/** @polymerBehavior */
+	D2L.PolymerBehaviors.FileUploader.LocalizeBehavior = [
+		D2L.PolymerBehaviors.LocalizeBehavior,
+		D2L.PolymerBehaviors.FileUploader.LocalizeBehaviorImpl
+	];
 </script>

--- a/test/d2l-file-uploader.html
+++ b/test/d2l-file-uploader.html
@@ -25,12 +25,7 @@
 		</test-fixture>
 		<test-fixture id="language">
 			<template>
-				<d2l-file-uploader language="fr-CA"></d2l-file-uploader>
-			</template>
-		</test-fixture>
-		<test-fixture id="language-fallback">
-			<template>
-				<d2l-file-uploader language="fr-ZZ"></d2l-file-uploader>
+				<d2l-file-uploader></d2l-file-uploader>
 			</template>
 		</test-fixture>
 		<test-fixture id="feedback">
@@ -41,7 +36,12 @@
 		<script>
 			describe('d2l-file-uploader', function() {
 
-				var elem;
+				var elem, htmlElem;
+
+				beforeEach(function() {
+					htmlElem = window.document.getElementsByTagName('html')[0];
+					htmlElem.removeAttribute('lang');
+				});
 
 				describe('basic', function() {
 
@@ -141,24 +141,15 @@
 				describe('language', function() {
 
 					beforeEach(function() {
+						htmlElem.setAttribute('lang', 'fr');
 						elem = fixture('language');
-					});
-
-					it('should have language of "fr-CA"', function() {
-						expect(elem.language).to.equal('fr-ca');
-						expect(elem.$$('.d2l-file-uploader-drop-zone > div > span:first-child').innerHTML).to.equal('Glissez-déposez ou&nbsp;');
-					});
-				});
-
-				describe('language fallback', function() {
-					beforeEach(function() {
-						elem = fixture('language-fallback');
 					});
 
 					it('should have language of "fr"', function() {
 						expect(elem.language).to.equal('fr');
 						expect(elem.$$('.d2l-file-uploader-drop-zone > div > span:first-child').innerHTML).to.equal('Glissez-déposez ou&nbsp;');
 					});
+
 				});
 
 				describe('feedback', function() {


### PR DESCRIPTION
I've switched this over to use `d2l-localize-behavior` from `app-localize-behavior`.

The main change here is that specifying `<d2l-file-uploader language="whatever">` is no longer needed -- it will automatically pull the language off the `<html lang="fr">` element/attribute. So a much more scalable way to do localization in our web components.

I feel like this should result in a major version bump for the component, since it's changing the way localization is specified.