### PR TITLE
US90047: Updated translations for changed drag and drop string

### DIFF
--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -17,79 +17,79 @@
 							'choose_one_file_to_upload': 'Choose one file to upload'
 						},
 						'ar': {
-							'file_upload_text': 'اسحب ملفًا وافلته في أي مكان على هذه الشاشة أو ',
+							'file_upload_text': 'السحب والإفلات أو',
 							'browse': 'استعراض',
 							'browse_files': 'استعراض الملفات',
 							'choose_one_file_to_upload': 'اختر ملفًا لتحميله'
 						},
 						'de': {
-							'file_upload_text': 'Datei an eine beliebige Stelle dieses Bildschirms verschieben oder',
+							'file_upload_text': 'Mit Drag-and-Drop verschieben oder',
 							'browse': 'durchsuchen',
 							'browse_files': 'Dateien durchsuchen',
 							'choose_one_file_to_upload': 'Wählen Sie eine Datei zum Hochladen aus'
 						},
 						'es': {
-							'file_upload_text': 'Arrastre y suelte un archivo en cualquier parte de esta pantalla o',
+							'file_upload_text': 'Arrastrar y soltar o',
 							'browse': 'examinar',
 							'browse_files': 'Examinar archivos',
 							'choose_one_file_to_upload': 'Elija un archivo para cargar'
 						},
 						'fr': {
-							'file_upload_text': 'Glissez-déposez ou',
+							'file_upload_text': 'Glisser-déposer ou',
 							'browse': 'parcourir',
 							'browse_files': 'Parcourir les fichiers',
 							'choose_one_file_to_upload': 'Choisir un fichier à téléverser'
 						},
 						'ja': {
-							'file_upload_text': 'この画面にファイルをドラッグ＆ドロップ、または',
+							'file_upload_text': 'ドラッグ＆ドロップまたは',
 							'browse': '参照',
 							'browse_files': 'ファイルの参照',
 							'choose_one_file_to_upload': 'アップロードするファイルを 1 つ選択'
 						},
 						'ko': {
-							'file_upload_text': '파일을 이 화면의 아무 곳에서 끌어서 놓거나',
+							'file_upload_text': '끌어서 놓기 또는',
 							'browse': '찾아보기',
 							'browse_files': '파일 찾아보기',
 							'choose_one_file_to_upload': '업로드할 파일 하나 선택'
 						},
 						'nl': {
-							'file_upload_text': 'Sleep een bestand en zet het ergens op dit scherm neer of',
+							'file_upload_text': 'Sleep en zet neer of',
 							'browse': 'blader',
 							'browse_files': 'Door bestanden bladeren',
 							'choose_one_file_to_upload': 'Kies een bestand dat u wilt uploaden'
 						},
 						'pt': {
-							'file_upload_text': 'Arraste e solte um arquivo em qualquer lugar nesta tela ou',
+							'file_upload_text': 'Arrastar e soltar ou',
 							'browse': 'procurar',
 							'browse_files': 'Procurar arquivos',
 							'choose_one_file_to_upload': 'Escolha um arquivo para carregar'
 						},
 						'sv': {
-							'file_upload_text': 'Dra och släpp en fil var som helst på skärmen eller',
+							'file_upload_text': 'Dra och släpp eller',
 							'browse': 'bläddra',
 							'browse_files': 'Bläddra bland filer',
 							'choose_one_file_to_upload': 'Välj en fil att ladda upp'
 						},
 						'tr': {
-							'file_upload_text': 'Bir dosyayı bu ekranda herhangi bir yere sürükleyip bırakın ya da',
+							'file_upload_text': 'Sürükleyip bırakın ya da',
 							'browse': 'göz atın',
 							'browse_files': 'Dosyalara Göz At',
 							'choose_one_file_to_upload': 'Yüklemek için bir dosya seçin'
 						},
 						'zh': {
-							'file_upload_text': '拖放一个文件到该屏幕的任何位置或者',
+							'file_upload_text': '拖放或者',
 							'browse': '浏览',
 							'browse_files': '浏览文件',
 							'choose_one_file_to_upload': '选择一个要上传的文件'
 						},
 						'zh-cn': {
-							'file_upload_text': '拖放一个文件到该屏幕的任何位置或者',
+							'file_upload_text': '拖放或者',
 							'browse': '浏览',
 							'browse_files': '浏览文件',
 							'choose_one_file_to_upload': '选择一个要上传的文件'
 						},
 						'zh-tw': {
-							'file_upload_text': '將一個檔案拖放至此畫面上的任何位置，或者',
+							'file_upload_text': '拖放或',
 							'browse': '瀏覽',
 							'browse_files': '瀏覽檔案',
 							'choose_one_file_to_upload': '選擇要上傳的檔案'

--- a/test/d2l-file-uploader.html
+++ b/test/d2l-file-uploader.html
@@ -147,7 +147,7 @@
 
 					it('should have language of "fr"', function() {
 						expect(elem.language).to.equal('fr');
-						expect(elem.$$('.d2l-file-uploader-drop-zone > div > span:first-child').innerHTML).to.equal('Glissez-déposez ou&nbsp;');
+						expect(elem.$$('.d2l-file-uploader-drop-zone > div > span:first-child').innerHTML).to.equal('Glisser-déposer ou&nbsp;');
 					});
 
 				});


### PR DESCRIPTION
This is just to update the translated strings following our change for the drag and drop string (from the longer string to 'Drag and drop or').