### PR TITLE
Make file-uploader accept focus() calls

### DIFF
--- a/d2l-file-uploader.js
+++ b/d2l-file-uploader.js
@@ -11,6 +11,7 @@
 import '@polymer/polymer/polymer-legacy.js';
 
 import 'd2l-colors/d2l-colors.js';
+import 'd2l-polymer-behaviors/d2l-focusable-behavior.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';
 import './localize-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -171,7 +172,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-file-uploader">
 				<span class="d2l-file-uploader-input-container">
 					<span id="d2l-file-uploader-offscreen">[[label]]</span>
 					<label class="d2l-file-uploader-browse-label">
-						<input class="d2l-file-uploader-input" type="file" aria-describedby="d2l-file-uploader-offscreen" multiple="[[multiple]]" on-change="_fileSelectHandler" on-focus="__onInputFocus" on-blur="__onInputBlur">
+						<input class="d2l-file-uploader-input d2l-focusable" type="file" aria-describedby="d2l-file-uploader-offscreen" multiple="[[multiple]]" on-change="_fileSelectHandler" on-focus="__onInputFocus" on-blur="__onInputBlur">
 						<span class="d2l-file-uploader-browse">[[localize('browse')]]</span>
 						<span class="d2l-file-uploader-browse-files">[[localize('browse_files')]]</span>
 					</label>
@@ -180,7 +181,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-file-uploader">
 		</div>
 	</template>
 
-	
+
 
 </dom-module>`;
 
@@ -189,7 +190,8 @@ Polymer({
 	is: 'd2l-file-uploader',
 
 	behaviors: [
-		D2L.PolymerBehaviors.FileUploader.LocalizeBehavior
+		D2L.PolymerBehaviors.FileUploader.LocalizeBehavior,
+		D2L.PolymerBehaviors.FocusableBehavior
 	],
 
 	properties: {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",
-    "lint:wc": "polymer lint",
+    "lint:wc": "polymer lint d2l-file-uploader.js",
     "test": "npm run lint && npm run test:polymer:local",
     "test:polymer:local": "polymer test --skip-plugin sauce",
     "test:polymer:sauce": "polymer test --skip-plugin local"
@@ -22,6 +22,7 @@
     "@polymer/iron-test-helpers": "^3.0.0-pre.18",
     "@webcomponents/webcomponentsjs": "^2.2.1",
     "babel-eslint": "^10.0.1",
+    "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "eslint": "^4.15.0",
     "eslint-config-brightspace": "^0.4.0",

--- a/test/d2l-file-uploader.html
+++ b/test/d2l-file-uploader.html
@@ -59,6 +59,12 @@ describe('d2l-file-uploader', function() {
 			expect(elem.language).to.equal('en');
 		});
 
+		it('should accept focus', function() {
+			expect(document.activeElement).to.not.equal(elem);
+			elem.focus();
+			expect(document.activeElement).to.equal(elem);
+		});
+
 	});
 
 	describe('multiple', function() {


### PR DESCRIPTION
This allows consumers to call `.focus()` on the `file-uploader` element and it will transfer focus to the internal `<input>` element.